### PR TITLE
readme: remove deprecated --save npm install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Tornis takes a deferred approach. Rather than bind directly to native events, To
 Tornis can be installed from source and included as a script tag, or from npm. Npm is the preferred method. Open your project directory in your command line or terminal, then run:
 
 ```
-npm install tornis --save
+npm install tornis
 ```
 
 ## The state object


### PR DESCRIPTION
`npm install` no longer has a `--save` option (the equivalent is now `--save-prod`),
and the `--save`/`--save-prod` behavior (adding `install`ed packages to the package.json `dependencies`) has been the `npm install` default since npm v5.0.0. So no flag is needed.

This PR removes `--save` from the suggested npm installation command